### PR TITLE
Update CNAME file to use www.code-island.org

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-code-island.org
+www.code-island.org


### PR DESCRIPTION
The DNS config for the apex domain code-island.org is not correct at this time.  The DNS config for www.code-island.org is correct.  Accepting this change will make sure users do not get redirected to the apex domain.